### PR TITLE
Added verification for at least number of times

### DIFF
--- a/src/main/java/com/xebialabs/restito/builder/verify/VerifyHttp.java
+++ b/src/main/java/com/xebialabs/restito/builder/verify/VerifyHttp.java
@@ -58,13 +58,27 @@ public class VerifyHttp {
             throw new AssertionError(format("Expected to happen %s time(s), but happened %s times instead", t, foundCalls.size()));
         }
 
-        List<Call> callsAfterLastFound = foundCalls.size() == 0 ? calls :
-                calls.subList(
-                        calls.indexOf(foundCalls.get(foundCalls.size() - 1)) + 1,
-                        calls.size()
-                );
+        return new VerifySequenced(getCallsAfterLastFound(foundCalls));
+    }
 
-        return new VerifySequenced(callsAfterLastFound);
+    /**
+     * There should be at least <i>t</i> calls which satisfies the given conditions
+     */
+    public VerifySequenced atLeast(int t, Condition... conditions) {
+        final List<Call> foundCalls = filterByConditions(conditions);
+        if (t > foundCalls.size()) {
+            throw new AssertionError(format("Expected to happen at least %s time(s), but happened %s times instead", t, foundCalls.size()));
+        }
+
+        return new VerifySequenced(getCallsAfterLastFound(foundCalls));
+    }
+
+    private List<Call> getCallsAfterLastFound(final List<Call> foundCalls) {
+        return foundCalls.size() == 0 ? calls :
+                    calls.subList(
+                            calls.indexOf(foundCalls.get(foundCalls.size() - 1)) + 1,
+                            calls.size()
+                    );
     }
 
     private List<Call> filterByConditions(Condition[] conditions) {

--- a/src/test/java/com/xebialabs/restito/builder/verify/VerifyHttpTest.java
+++ b/src/test/java/com/xebialabs/restito/builder/verify/VerifyHttpTest.java
@@ -60,6 +60,24 @@ public class VerifyHttpTest {
         verifyHttp(stubServer).times(10, conditionTrue());
     }
 
+    @Test(expected = AssertionError.class)
+    public void shouldFailWhenHappensMoreTimesThenExpected() {
+        when(stubServer.getCalls()).thenReturn(Lists.<Call>newArrayList(mock(Call.class), mock(Call.class), mock(Call.class)));
+        verifyHttp(stubServer).times(2, conditionTrue());
+    }
+
+    @Test
+    public void shouldPassWhenHappensMoreTimesThenAtLeastExpected() {
+        when(stubServer.getCalls()).thenReturn(Lists.<Call>newArrayList(mock(Call.class), mock(Call.class), mock(Call.class)));
+        verifyHttp(stubServer).atLeast(2, conditionTrue());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void shouldFailWhenHappensLessTimesThenAtLeastExpected() {
+        when(stubServer.getCalls()).thenReturn(Lists.<Call>newArrayList(mock(Call.class), mock(Call.class), mock(Call.class)));
+        verifyHttp(stubServer).times(4, conditionTrue());
+    }
+
     @Test
     public void shouldPassWhen2CallsInOrderHappenAsExpected() {
         when(stubServer.getCalls()).thenReturn(Lists.<Call>newArrayList(getCall, postCall));


### PR DESCRIPTION
When stubbing servers for integration tests, there are scenario's where
it is unknown how often the server is invoked (e.g. when using a timer
trigger). To aid this use-case, the atLeast() method was added, so that
the test passes also when the server is invoked multiple times.
