### PR TITLE
Using the grizzly PortRange based port choosing 

### DIFF
--- a/src/main/java/com/xebialabs/restito/server/StubServer.java
+++ b/src/main/java/com/xebialabs/restito/server/StubServer.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.mina.util.AvailablePortFinder;
+import org.glassfish.grizzly.PortRange;
 import org.glassfish.grizzly.http.server.*;
 import org.glassfish.grizzly.http.util.HttpStatus;
 import org.glassfish.grizzly.ssl.SSLContextConfigurator;
@@ -47,7 +48,7 @@ public class StubServer {
      */
     public StubServer(Stub... stubs) {
         this.stubs = new ArrayList<>(Arrays.asList(stubs));
-        simpleServer = HttpServer.createSimpleServer(null, AvailablePortFinder.getNextAvailable(DEFAULT_PORT));
+        simpleServer = HttpServer.createSimpleServer(null, new PortRange(DEFAULT_PORT, AvailablePortFinder.MAX_PORT_NUMBER));
     }
 
     /**

--- a/src/test/java/com/xebialabs/restito/server/StubServerTest.java
+++ b/src/test/java/com/xebialabs/restito/server/StubServerTest.java
@@ -1,5 +1,6 @@
 package com.xebialabs.restito.server;
 
+import org.apache.mina.util.AvailablePortFinder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,8 +31,8 @@ public class StubServerTest {
     }
 
     @Test
-    public void shouldStartServerOnDefaultPort() {
-        assertEquals(6666, server.getPort());
+    public void shouldStartServerInRangeStartingFromDefaultPort() {
+        assertTrue("Server port not in range", server.getPort() >= StubServer.DEFAULT_PORT && server.getPort() <= AvailablePortFinder.MAX_PORT_NUMBER);
         server.stop();
     }
 
@@ -39,7 +40,7 @@ public class StubServerTest {
     public void shouldStartServerOnRandomPortWhenDefaultPortIsBusy() {
         StubServer server1 = new StubServer().run();
         StubServer server2 = new StubServer().run();
-        assertTrue(server2.getPort() > server1.getPort());
+        assertTrue(server2.getPort() != server1.getPort());
     }
 
     @Test


### PR DESCRIPTION
..so that it's not failing when some other process intercepts the port that we've just chosen.
While using PortRange Grizzly tries to bind to the port and stays with it when it succeeded - feels like a much better way to go. In our project we see a lot of ports interceptions on cloud based CI's (Travis).