### PR TITLE
support post body validation using json path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     compile 'org.glassfish.grizzly:grizzly-http-server:2.3.17'
     compile 'com.sun.jersey:jersey-grizzly2:1.18.3'
 
+	compile 'com.jayway.jsonpath:json-path:2.0.0'
+
     compile 'org.apache.mina:mina-core:2.0.4'
 
     testCompile 'org.hamcrest:hamcrest-all:1.3'

--- a/src/main/java/com/xebialabs/restito/semantics/Condition.java
+++ b/src/main/java/com/xebialabs/restito/semantics/Condition.java
@@ -4,6 +4,8 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.regex.Pattern;
+
+import com.jayway.jsonpath.JsonPath;
 import org.apache.mina.util.Base64;
 import org.glassfish.grizzly.http.Method;
 import org.slf4j.Logger;
@@ -199,6 +201,15 @@ public class Condition {
             @Override
             public boolean apply(Call input) {
                 return input.getPostBody().matches(pattern.pattern());
+            }
+        });
+    }
+
+    public static Condition withPostBodyContainingJsonPath(final String pattern, final String value) {
+        return new Condition(new Predicate<Call>() {
+            @Override
+            public boolean apply(Call input) {
+                return value.equals(JsonPath.parse(input.getPostBody()).read(pattern));
             }
         });
     }

--- a/src/main/java/com/xebialabs/restito/semantics/Condition.java
+++ b/src/main/java/com/xebialabs/restito/semantics/Condition.java
@@ -205,6 +205,15 @@ public class Condition {
         });
     }
 
+    /**
+     * With Valid Json Path.
+     * Check to see if incoming path has a valid string value selected via a <a href="https://github.com/jayway/JsonPath/">
+     * JSONPath</a> expression.
+     *
+     * @param - Json Path
+     * @param - value to check against
+     * @return
+     */
     public static Condition withPostBodyContainingJsonPath(final String pattern, final String value) {
         return new Condition(new Predicate<Call>() {
             @Override

--- a/src/test/java/com/xebialabs/restito/semantics/ConditionTest.java
+++ b/src/test/java/com/xebialabs/restito/semantics/ConditionTest.java
@@ -165,6 +165,19 @@ public class ConditionTest {
         assertFalse(condition.check(call));
     }
 
+
+    @Test
+    public void shouldDistinguishByStringInJsonPath() {
+        Condition condition = Condition.withPostBodyContainingJsonPath("$.name", "foo");
+
+
+        when(call.getPostBody()).thenReturn("{\"name\":\"foo\"}");
+        assertTrue(condition.check(call));
+
+        condition = Condition.withPostBodyContainingJsonPath("$.name","bar");
+        assertFalse(condition.check(call));
+    }
+
     @Test
     @SuppressWarnings("deprecation")
     public void shouldDistinguishByRegexpMatchInBody() {


### PR DESCRIPTION
It is useful to verify incoming JSON data.  JsonPath allows for doing xpath like queries against a String.

verifyHttp(server).once(method(Method.POST),
               withPostBodyContainingJsonPath("$.store.book[0].title","GitHub"),

verifyHttp(server).once(method(Method.POST),
               withPostBodyContainingJsonPath("$.recordId","1234"),
               withPostBodyContainingJsonPath("$.method","PUT"));