### PR TITLE
Added "request" field to Call class

### DIFF
--- a/src/main/java/com/xebialabs/restito/semantics/Call.java
+++ b/src/main/java/com/xebialabs/restito/semantics/Call.java
@@ -20,6 +20,7 @@ public class Call {
     private String authorization;
     private Map<String, String> headers = new HashMap<>();
     private Map<String, String[]> parameters = new HashMap<>();
+    private Request request;
 
     private Call() {
     }
@@ -30,6 +31,7 @@ public class Call {
     public static Call fromRequest(final Request request) {
         Call call = new Call();
 
+        call.request = request;
         call.method = request.getMethod();
         call.authorization = request.getAuthorization();
         call.uri = request.getRequestURI();
@@ -102,6 +104,13 @@ public class Call {
      */
     public String getAuthorization() {
         return authorization;
+    }
+
+    /**
+     * Returns raw HTTP request
+     */
+    public Request getRequest() {
+        return request;
     }
 }
 


### PR DESCRIPTION
Added "request" field to Call class so that conditions can be built based on custom HTTP request properties.

I want to build custom conditions based on client remote address (request.getRemoteAddr) or request.getQueryString() among others. With my commit there will be access to the whole HTTP request object in Call class and such custom conditions will be possible. Without full request access I cannot mock my service behavior.