### PR TITLE
Allow to match for other types then String in Condition.withPostBodyContainingJsonPath() method

### DIFF
--- a/src/main/java/com/xebialabs/restito/semantics/Condition.java
+++ b/src/main/java/com/xebialabs/restito/semantics/Condition.java
@@ -214,7 +214,7 @@ public class Condition {
      * @param - value to check against
      * @return
      */
-    public static Condition withPostBodyContainingJsonPath(final String pattern, final String value) {
+    public static Condition withPostBodyContainingJsonPath(final String pattern, final Object value) {
         return new Condition(new Predicate<Call>() {
             @Override
             public boolean apply(Call input) {

--- a/src/test/java/com/xebialabs/restito/semantics/ConditionTest.java
+++ b/src/test/java/com/xebialabs/restito/semantics/ConditionTest.java
@@ -165,7 +165,6 @@ public class ConditionTest {
         assertFalse(condition.check(call));
     }
 
-
     @Test
     public void shouldDistinguishByStringInJsonPath() {
         Condition condition = Condition.withPostBodyContainingJsonPath("$.name", "foo");
@@ -175,6 +174,18 @@ public class ConditionTest {
         assertTrue(condition.check(call));
 
         condition = Condition.withPostBodyContainingJsonPath("$.name","bar");
+        assertFalse(condition.check(call));
+    }
+
+    @Test
+    public void shouldDistinguishNumberByStringInJsonPath() {
+        Condition condition = Condition.withPostBodyContainingJsonPath("$.name", 5);
+
+
+        when(call.getPostBody()).thenReturn("{\"name\": 5}");
+        assertTrue(condition.check(call));
+
+        condition = Condition.withPostBodyContainingJsonPath("$.name",6);
         assertFalse(condition.check(call));
     }
 

--- a/src/test/java/com/xebialabs/restito/semantics/ConditionTest.java
+++ b/src/test/java/com/xebialabs/restito/semantics/ConditionTest.java
@@ -179,13 +179,13 @@ public class ConditionTest {
 
     @Test
     public void shouldDistinguishNumberByStringInJsonPath() {
-        Condition condition = Condition.withPostBodyContainingJsonPath("$.name", 5);
+        Condition condition = Condition.withPostBodyContainingJsonPath("$.age", 5);
 
 
-        when(call.getPostBody()).thenReturn("{\"name\": 5}");
+        when(call.getPostBody()).thenReturn("{\"age\": 5}");
         assertTrue(condition.check(call));
 
-        condition = Condition.withPostBodyContainingJsonPath("$.name",6);
+        condition = Condition.withPostBodyContainingJsonPath("$.age",6);
         assertFalse(condition.check(call));
     }
 


### PR DESCRIPTION
Currently, the `Condition.withPostBodyContainingJsonPath()` method takes a `String` a second type's argument (value) and calls `equals()` method on it to check if a given value is equal to value from JSON. But the value returned from JSON is not always a String but it's a true type of field data, so if I have a JSON like following:
```
{
    "age" : 10
}
```

and I call:

`Condition.withPostBodyContainingJsonPath("age", "10")`

it is not matching as `10` is mapped to `Integer` type and of course `"10".equals(10) == false`

So my proposal is to allow to change a `value`'s type from `String` to `Object` in `Condition.withPostBodyContainingJsonPath()` method to allow passing any type of object to match.