### PR TITLE
JUnit 4 rule to start stub server

### DIFF
--- a/src/main/java/com/xebialabs/restito/support/junit/StartServer.java
+++ b/src/main/java/com/xebialabs/restito/support/junit/StartServer.java
@@ -1,0 +1,44 @@
+package com.xebialabs.restito.support.junit;
+
+import org.junit.rules.ExternalResource;
+
+import com.xebialabs.restito.server.StubServer;
+
+public class StartServer extends ExternalResource {
+
+    private final StubServer server;
+
+    public StubServer getServer() {
+        return this.server;
+    }
+
+    public String getServerUrl() {
+        return "http://localhost:" + this.server.getPort();
+    }
+
+    public StartServer() {
+        this.server = new StubServer();
+    }
+
+    public StartServer(final int port) {
+        this.server = new StubServer(port);
+    }
+
+    public StartServer(final int portRangeStart, final int portRangeEnd) {
+        this.server = new StubServer(portRangeStart, portRangeEnd);
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        super.before();
+
+        this.server.start();
+    }
+
+    @Override
+    protected void after() {
+        super.after();
+
+        this.server.stop();
+    }
+}

--- a/src/test/java/com/xebialabs/restito/support/junit/StartServerTest.java
+++ b/src/test/java/com/xebialabs/restito/support/junit/StartServerTest.java
@@ -1,0 +1,45 @@
+package com.xebialabs.restito.support.junit;
+
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.http.HttpStatus.SC_OK;
+
+import org.glassfish.grizzly.http.util.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.jayway.restassured.RestAssured;
+import com.xebialabs.restito.builder.stub.StubHttp;
+import com.xebialabs.restito.semantics.Action;
+import com.xebialabs.restito.semantics.Condition;
+
+public class StartServerTest {
+
+    @Rule
+    public StartServer startServer = new StartServer();
+
+    @Before
+    public void setUpRestAssured() {
+        RestAssured.port = this.startServer.getServer().getPort();
+    }
+
+    @Test
+    public void shouldStartServerForInstanceRule() throws Exception {
+        StubHttp.whenHttp(this.startServer.getServer())
+                .match(Condition.get("/"))
+                .then(Action.success());
+        RestAssured.expect()
+                .statusCode(SC_OK)
+                .when().get("/");
+    }
+
+    @Test
+    public void shouldStartAnotherServerForInstanceRule() throws Exception {
+        StubHttp.whenHttp(this.startServer.getServer())
+                .match(Condition.get("/"))
+                .then(Action.status(HttpStatus.NOT_FOUND_404));
+        RestAssured.expect()
+                .statusCode(SC_NOT_FOUND)
+                .when().get("/");
+    }
+}


### PR DESCRIPTION
Its just a simple junit 4 rule that allows you to have an annotated field that starts up the `StubServer`.

possibly its related to https://github.com/mkotsur/restito/issues/19