### PR TITLE
Clearing StubServer state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,10 @@ task sourcesJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allSource
 }
 
+javadoc {
+	options.addStringOption('Xdoclint:none', '-quiet')
+}
+
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir

--- a/src/main/java/com/xebialabs/restito/server/StubServer.java
+++ b/src/main/java/com/xebialabs/restito/server/StubServer.java
@@ -86,6 +86,31 @@ public class StubServer {
     }
 
     /**
+     * Removes any previously registered stubs.
+     */
+    public StubServer clearStubs() {
+        this.stubs.clear();
+        return this;
+    }
+
+    /**
+     * Removes any registered stubs calls.
+     */
+    public StubServer clearCalls() {
+        this.calls.clear();
+        return this;
+    }
+
+    /**
+     * Clears the server state.
+     */
+    public StubServer clear() {
+        this.clearStubs();
+        this.clearCalls();
+        return this;
+    }
+
+    /**
      * Starts the server
      */
     public StubServer run() {

--- a/src/test/java/com/xebialabs/restito/server/StubServerTest.java
+++ b/src/test/java/com/xebialabs/restito/server/StubServerTest.java
@@ -82,4 +82,40 @@ public class StubServerTest {
             whenHttp(server).match(get("/newstub")).then(ok());
         }
     }
+
+    @Test
+    public void shouldClearRegisteredStubs() {
+        whenHttp(server).match(get("/")).then(ok());
+        assertEquals(1, server.getStubs().size());
+
+        server.clearStubs();
+
+        assertEquals(0, server.getStubs().size());
+    }
+
+    @Test
+    public void shouldClearStubCalls() {
+        whenHttp(server).match(get("/")).then(ok());
+        expect().statusCode(200).get("/");
+
+        assertEquals(1, server.getCalls().size());
+
+        server.clearCalls();
+
+        assertEquals(0, server.getCalls().size());
+    }
+
+    @Test
+    public void shouldClearStubAndCalls() {
+        whenHttp(server).match(get("/")).then(ok());
+        expect().statusCode(200).get("/");
+
+        assertEquals(1, server.getStubs().size());
+        assertEquals(1, server.getCalls().size());
+
+        server.clear();
+
+        assertEquals(0, server.getStubs().size());
+        assertEquals(0, server.getCalls().size());
+    }
 }


### PR DESCRIPTION
Hi,

I have prepared this tiny PR, that adds additional clear method to the StubServer. The motivation is that we were running a fair number of tests agains the Restito stubs, requiring that after each test we would perform StubServer.stop to deregister the behaviour, the down side was that this would require to restart the HTTP server (re-bind to port, setup listing threads etc.) instead I would like to propose to add the clear method that would just clear the stubs and calls lists.

As the result of this change we have experienced 1.11 speed up (maybe that isn't much, but still fair gain) of our integration tests.

Thanks