### PR TITLE
Fixed for Wikipedia's redirect to HTTPS

### DIFF
--- a/examples/popular-page/src/main/java/com/xebialabs/restito/examples/App.java
+++ b/examples/popular-page/src/main/java/com/xebialabs/restito/examples/App.java
@@ -4,7 +4,7 @@ public class App {
 
     public static void main(String[] args) throws Exception {
 
-        PageRevision revision = new WikiClient("http://en.wikipedia.org")
+        PageRevision revision = new WikiClient("https://en.wikipedia.org")
                 .getMostRecentRevision("The X-Files", "Star Trek", "The Simpsons", "Game of Thrones");
 
         System.out.println("The most recent change was made to '" + revision.name +


### PR DESCRIPTION
The examples/popular-pages did not work anymore due to HTTP>HTTPS redirect from Wikipedia. This fixes the issue.