### PR TITLE
Add the ability to specify keystore through the standard java system properties.

### DIFF
--- a/src/main/java/com/xebialabs/restito/server/StubServer.java
+++ b/src/main/java/com/xebialabs/restito/server/StubServer.java
@@ -131,6 +131,10 @@ public class StubServer {
     }
 
     private SSLContextConfigurator getSslConfig() throws IOException {
+        if(SSLContextConfigurator.DEFAULT_CONFIG.validateConfiguration(true))
+        {
+            return SSLContextConfigurator.DEFAULT_CONFIG;
+        }
         SSLContextConfigurator defaultConfig = SSLContextConfigurator.DEFAULT_CONFIG;
         String keystore_server = createCertificateStore("keystore_server");
         String truststore_server = createCertificateStore("truststore_server");

--- a/src/test/java/guide/UsingHttpsTest.java
+++ b/src/test/java/guide/UsingHttpsTest.java
@@ -34,7 +34,7 @@ public class UsingHttpsTest {
 
     @Before
     public void start() {
-        server = new StubServer().secured().run();
+        server = new StubServer().secured();
         RestAssured.port = server.getPort();
     }
 
@@ -45,6 +45,27 @@ public class UsingHttpsTest {
 
     @Test
     public void shouldPassWhenExpectedStubDidHappen() throws GeneralSecurityException, IOException {
+        server.run();
+        whenHttp(server).match(get("/asd")).then(ok()).mustHappen();
+
+        HttpResponse execute = sslReadyHttpClient().execute(new HttpGet("https://localhost:" + server.getPort() + "/asd"));
+
+        assertThat(execute.getStatusLine().getStatusCode(), equalTo(200));
+        ensureHttp(server).gotStubsCommitmentsDone();
+    }
+
+    @Test
+    public void shouldBePossibleToSpecifyKeyStoresWithStandardProperties() throws GeneralSecurityException, IOException {
+
+        System.setProperty("javax.net.ssl.trustStore","build/resources/main/keystore_server");
+
+        System.setProperty("javax.net.ssl.keyStore","build/resources/main/truststore_server");
+
+        System.setProperty("javax.net.ssl.trustStorePassword","secret");
+
+        System.setProperty("javax.net.ssl.keyStorePassword","secret");
+
+        server.run();
         whenHttp(server).match(get("/asd")).then(ok()).mustHappen();
 
         HttpResponse execute = sslReadyHttpClient().execute(new HttpGet("https://localhost:" + server.getPort() + "/asd"));


### PR DESCRIPTION
I needed the ability to use a keystore and truststore that my framework trusted for my integration tests but I couldn't do that without making a small code change.