### PR TITLE
New support for sequenced stub actions implemented.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	testCompile 'org.slf4j:slf4j-simple:1.7.5'
 
 	testCompile 'org.mockito:mockito-core:1.10.17'
-	compile 'org.glassfish.grizzly:grizzly-http-server:2.3.17'
+	compile 'org.glassfish.grizzly:grizzly-http-server:2.3.24'
 
 	compile 'com.jayway.jsonpath:json-path:2.1.0'
 

--- a/guide.md
+++ b/guide.md
@@ -13,6 +13,7 @@ One test can be better then dozen lines of documentation, so there are tests in 
     * [Basic authentication](#basic_authentication)
     * [Automatic content type](#automatic_content_type)
     * [Expected stubs](#expected_stubs)
+    * [Sequenced stub actions](#sequenced_stub_actions)
     * [Autodiscovery of stubs content](#autodiscovery_of_stubs_content) <sup style="color: orange">Experimental!</sup>
 * [Verifying calls to server](#verifying_calls_to_server)
     * [Simple verifications](#simple_verifications)
@@ -31,14 +32,14 @@ There is a [nice example](https://github.com/mkotsur/restito/blob/master/example
 # Starting and stopping stub server
 
 ```java
-	@Before
-	public void start() {
-		server = new StubServer().run();
-	}
+    @Before
+    public void start() {
+        server = new StubServer().run();
+    }
 
-	...
+    ...
 
-	@After
+    @After
     public void stop() {
         server.stop();
     }
@@ -50,12 +51,12 @@ There is a [nice example](https://github.com/mkotsur/restito/blob/master/example
 By default, [StubServer.DEFAULT_PORT](http://mkotsur.github.com/restito/javadoc/current/com/xebialabs/restito/server/StubServer.html#DEFAULT_PORT) is used, but if it's busy, then next available will be taken.
 
 ```java
-	@Test
-	public void shouldStartServerOnRandomPortWhenDefaultPortIsBusy() {
-		StubServer server1 = new StubServer().run();
-		StubServer server2 = new StubServer().run();
-		assertTrue(server2.getPort() > server1.getPort());
-	}
+    @Test
+    public void shouldStartServerOnRandomPortWhenDefaultPortIsBusy() {
+        StubServer server1 = new StubServer().run();
+        StubServer server2 = new StubServer().run();
+        assertTrue(server2.getPort() > server1.getPort());
+    }
 ```
 If you want to specify port explicitly, then you can do something like that:
 
@@ -104,9 +105,9 @@ import static com.xebialabs.restito.builder.stub.StubHttp.whenHttp;
 import static com.xebialabs.restito.semantics.Action.stringContent;
 import static com.xebialabs.restito.semantics.Condition.*;
     ...
-		whenHttp(server).
-				match(get("/asd"), parameter("bar", "foo")).
-				then(ok(), stringContent("GET asd with parameter bar=foo"));
+        whenHttp(server).
+                match(get("/asd"), parameter("bar", "foo")).
+                then(ok(), stringContent("GET asd with parameter bar=foo"));
 ```
 
 In this example your stub will return mentioned string content when GET request with HTTP parameter bar=foo is done.
@@ -117,7 +118,7 @@ If you want to use a custom condition, it's also very easy:
 
 ```java
 import static com.xebialabs.restito.semantics.Condition.*;
-import com.google.common.base.Predicate;
+import com.xebialabs.restito.semantics.Predicate;
 import com.xebialabs.restito.semantics.Call;
     ...
         Predicate<Call> uriEndsWithA = new Predicate<Call>() {
@@ -178,7 +179,7 @@ The first line makes sure that server responds with status `200` when client sen
 <a name="automatic_content_type" />
 ## Automatic content type
 
-When you use action [resourceContent\(\)](http://mkotsur.github.com/restito/javadoc/current/com/xebialabs/restito/semantics/Action.html#resourceContent\(java.lang.String\)), Restito will look at file extension and if it it's one of the types below, appropriate Content-Type will be set:
+When you use action [resourceContent\(\)](https://mkotsur.github.io/restito/javadoc/current/com/xebialabs/restito/semantics/Action.html#resourceContent-java.lang.String-), Restito will look at file extension and if it it's one of the types below, appropriate Content-Type will be set:
 
 * .xml => application/xml
 * .json => application/json
@@ -188,7 +189,23 @@ See [AutomaticContentTypeTest](https://github.com/mkotsur/restito/blob/master/sr
 <a name="expected_stubs" />
 ## Expected stubs
 
-Makes sure that certain stubbed condition has been called some number of times. See [StubExpectedTest](https://github.com/mkotsur/restito/blob/master/src/test/java/guide/StubExpectedTest.java) to learn how to do it.
+Makes sure that certain stubbed condition has been called some number of times. See [ExpectedStubTest](https://github.com/mkotsur/restito/blob/master/src/test/java/guide/ExpectedStubTest.java) to learn how to do it.
+
+<a name="sequenced_stub_actions" />
+## Sequenced stub actions
+
+You can easily chain stub actions:
+
+```java
+    whenHttp(server).
+            match(get("/demo")).
+            then(status(HttpStatus.OK_200),
+                 sequence(stringContent("Hello Restito."),
+                          stringContent("Hello, again!"))
+            );
+```
+
+See [SequencedSubActionsTest](https://github.com/mkotsur/restito/blob/master/src/test/java/guide/SequencedSubActionsTest.java).
 
 <a name="autodiscovery_of_stubs_content" />
 ## Autodiscovery of stubs content
@@ -228,7 +245,7 @@ To verify that some call to the server has happened once, you may use following 
     );
 ```
 
-For verifications you use the same conditions as for stubbing and complete list of them can be found at [Condition](http://mkotsur.github.com/restito/javadoc/current/com/xebialabs/restito/semantics/Condition.html) javadoc and [custom conditions](http://mkotsur.github.com/restito/javadoc/current/com/xebialabs/restito/semantics/Condition.html#custom\(com.google.common.base.Predicate\)) can easily be created.
+For verifications you use the same conditions as for stubbing and complete list of them can be found at [Condition](http://mkotsur.github.com/restito/javadoc/current/com/xebialabs/restito/semantics/Condition.html) javadoc and [custom conditions](https://mkotsur.github.io/restito/javadoc/current/com/xebialabs/restito/semantics/Condition.html#custom-com.xebialabs.restito.semantics.Predicate-) can easily be created.
 
 See [SimpleVerificationsTest](https://github.com/mkotsur/restito/blob/master/src/test/java/guide/SimpleVerificationsTest.java).
 
@@ -238,8 +255,8 @@ See [SimpleVerificationsTest](https://github.com/mkotsur/restito/blob/master/src
 
 You have more options to limit number of calls:
 
-* [never(Condition... conditions)](http://mkotsur.github.com/restito/javadoc/current/com/xebialabs/restito/builder/verify/VerifyHttp.html#never\(com.xebialabs.restito.semantics.Condition...\))
-* [times(int t, Condition... conditions)](http://mkotsur.github.com/restito/javadoc/current/com/xebialabs/restito/builder/verify/VerifyHttp.html#times\(int,%20com.xebialabs.restito.semantics.Condition...\))
+* [never(Condition... conditions)](https://mkotsur.github.io/restito/javadoc/current/com/xebialabs/restito/builder/verify/VerifyHttp.html#never-com.xebialabs.restito.semantics.Condition...-)
+* [times(int t, Condition... conditions)](https://mkotsur.github.io/restito/javadoc/current/com/xebialabs/restito/builder/verify/VerifyHttp.html#times-int-com.xebialabs.restito.semantics.Condition...-)
 
 See [LimitingNumberOfCallsTest](https://github.com/mkotsur/restito/blob/master/src/test/java/guide/LimitingNumberOfCallsTest.java).
 

--- a/src/main/java/com/xebialabs/restito/semantics/Action.java
+++ b/src/main/java/com/xebialabs/restito/semantics/Action.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Queue;
 
 import com.xebialabs.restito.support.file.FileHelper;
 import com.xebialabs.restito.support.resource.ResourceHelper;
@@ -287,6 +289,33 @@ public class Action implements Applicable {
                     action.apply(input);
                 }
 
+                return input;
+            }
+        });
+    }
+
+    /**
+     * Creates a sequence action which contains all passed actions and
+     * executes one by one of them in the same order if {@link Action#apply(Response)} is repeated.
+     * If all passed actions has been already applied it behaves like {@link #noop()} action.
+     *
+     * @param actions queue of actions to be used one by one when {@link Action#apply(Response)} invoked.
+     */
+    public static Action sequence(final Action... actions) {
+        return new Action(new Function<Response, Response>() {
+            private Queue<Action> queue = new LinkedList<>();
+            {
+                for (Action action : actions) {
+                    this.queue.offer(action);
+                }
+            }
+
+            @Override
+            public Response apply(Response input) {
+                Action next = queue.poll();
+                if (next != null) {
+                    input = next.apply(input);
+                }
                 return input;
             }
         });

--- a/src/test/java/com/xebialabs/restito/semantics/ActionTest.java
+++ b/src/test/java/com/xebialabs/restito/semantics/ActionTest.java
@@ -14,6 +14,7 @@ import static com.xebialabs.restito.semantics.Action.charset;
 import static com.xebialabs.restito.semantics.Action.composite;
 import static com.xebialabs.restito.semantics.Action.header;
 import static com.xebialabs.restito.semantics.Action.resourceContent;
+import static com.xebialabs.restito.semantics.Action.sequence;
 import static com.xebialabs.restito.semantics.Action.status;
 import static com.xebialabs.restito.semantics.Action.stringContent;
 import static org.mockito.Mockito.any;
@@ -131,4 +132,27 @@ public class ActionTest {
 
         verify(response).setStatus(HttpStatus.NOT_ACCEPTABLE_406);
     }
+
+    @Test
+    public void shouldCreateSequenceActionFromSingleAction() throws Exception {
+        Action action = sequence(stringContent("foo"));
+
+        action.apply(response);
+        verify(response.getOutputStream()).write("foo".getBytes());
+    }
+
+    @Test
+    public void shouldCreateSequenceActionFromActions() throws Exception {
+        Action action = sequence(stringContent("foo"), stringContent("bar"), stringContent("baz"));
+
+        action.apply(response);
+        verify(response.getOutputStream()).write("foo".getBytes());
+
+        action.apply(response);
+        verify(response.getOutputStream()).write("bar".getBytes());
+
+        action.apply(response);
+        verify(response.getOutputStream()).write("baz".getBytes());
+    }
+
 }

--- a/src/test/java/guide/SequencedSubActionsTest.java
+++ b/src/test/java/guide/SequencedSubActionsTest.java
@@ -11,14 +11,22 @@ import org.junit.Test;
 import static com.jayway.restassured.RestAssured.given;
 import static com.xebialabs.restito.builder.stub.StubHttp.whenHttp;
 import static com.xebialabs.restito.builder.verify.VerifyHttp.verifyHttp;
+import static com.xebialabs.restito.semantics.Action.composite;
 import static com.xebialabs.restito.semantics.Action.sequence;
 import static com.xebialabs.restito.semantics.Action.status;
 import static com.xebialabs.restito.semantics.Action.stringContent;
+import static com.xebialabs.restito.semantics.Condition.delete;
 import static com.xebialabs.restito.semantics.Condition.get;
 import static com.xebialabs.restito.semantics.Condition.method;
+import static com.xebialabs.restito.semantics.Condition.post;
 import static com.xebialabs.restito.semantics.Condition.put;
 import static com.xebialabs.restito.semantics.Condition.uri;
 import static com.xebialabs.restito.semantics.Condition.withPostBody;
+import static org.glassfish.grizzly.http.util.HttpStatus.BAD_REQUEST_400;
+import static org.glassfish.grizzly.http.util.HttpStatus.CONFLICT_409;
+import static org.glassfish.grizzly.http.util.HttpStatus.CREATED_201;
+import static org.glassfish.grizzly.http.util.HttpStatus.FORBIDDEN_403;
+import static org.glassfish.grizzly.http.util.HttpStatus.NOT_FOUND_404;
 import static org.glassfish.grizzly.http.util.HttpStatus.NO_CONTENT_204;
 import static org.glassfish.grizzly.http.util.HttpStatus.OK_200;
 import static org.hamcrest.Matchers.equalTo;
@@ -46,46 +54,146 @@ public class SequencedSubActionsTest {
     @Test
     public void shouldReturnDifferentBodyForSameRequest() {
         whenHttp(server).
-                match(get("/demo")).
+                match(get("/foo")).
                 then(status(OK_200),
                      sequence(stringContent("Hello Restito."),
                               stringContent("Hello, again!"))
                 );
 
         // First action from sequence:
-        given().get("/demo").then().assertThat().body(equalTo("Hello Restito."));
+        given().get("/foo").then().assertThat().body(equalTo("Hello Restito."));
         // Second action from sequence:
-        given().get("/demo").then().assertThat().body(equalTo("Hello, again!"));
+        given().get("/foo").then().assertThat().body(equalTo("Hello, again!"));
         // Noop action:
-        given().get("/demo").then().assertThat().body(isEmptyString());
+        given().get("/foo").then().assertThat().body(isEmptyString());
 
         verifyHttp(server).times(3,
                                  method(Method.GET),
-                                 uri("/demo"));
+                                 uri("/foo"));
     }
 
     @Test
-    public void shouldReturnDifferentBodyForSameRequestExpectedUsage() {
+    public void shouldReturnDifferentResponseTwoEndpoints() {
         whenHttp(server).
-                match(get("/demo")).
+                match(get("/foo")).
                 then(status(OK_200),
-                     sequence(stringContent("INITIAL VALUE"),
-                              stringContent("UPDATED VALUE"))
+                     sequence(stringContent("Hello Restito."),
+                              stringContent("Hello, again!"))
                 );
         whenHttp(server).
-                match(put("/demo"), withPostBody()).
+                match(get("/bar")).
+                then(sequence(status(NOT_FOUND_404),
+                              composite(status(OK_200), stringContent("body")),
+                              composite(status(FORBIDDEN_403), stringContent("admin required"))
+                     )
+                );
+
+        given().get("/foo").then().assertThat().statusCode(is(OK_200.getStatusCode())).body(equalTo("Hello Restito."));
+        given().get("/bar").then().assertThat().statusCode(is(NOT_FOUND_404.getStatusCode())).body(isEmptyString());
+        given().get("/foo").then().assertThat().statusCode(is(OK_200.getStatusCode())).body(equalTo("Hello, again!"));
+        given().get("/bar").then().assertThat().statusCode(is(OK_200.getStatusCode())).body(equalTo("body"));
+        given().get("/foo").then().assertThat().statusCode(is(OK_200.getStatusCode())).body(isEmptyString());
+        given().get("/bar").then().assertThat().statusCode(is(FORBIDDEN_403.getStatusCode())).body(equalTo("admin required"));
+
+        verifyHttp(server).times(3,
+                                 method(Method.GET),
+                                 uri("/foo"));
+        verifyHttp(server).times(3,
+                                 method(Method.GET),
+                                 uri("/bar"));
+    }
+
+    @Test
+    public void shouldReturnDifferentBodyAndStatusForSameRequestByTwoSequences() {
+        whenHttp(server).
+                match(post("/foo")).
+                then(sequence(status(CREATED_201),
+                              status(CONFLICT_409),
+                              status(CREATED_201),
+                              status(NOT_FOUND_404)),
+                     sequence(stringContent("status=CREATED"),
+                              stringContent("status=CONFLICT"),
+                              stringContent("status=CREATED2"))
+                );
+
+        given().post("/foo").then().assertThat().statusCode(is(201)).body(equalTo("status=CREATED"));
+        given().post("/foo").then().assertThat().statusCode(is(409)).body(equalTo("status=CONFLICT"));
+        given().post("/foo").then().assertThat().statusCode(is(201)).body(equalTo("status=CREATED2"));
+        given().post("/foo").then().assertThat().statusCode(is(404)).body(isEmptyString());
+        given().post("/foo").then().assertThat().body(isEmptyString());
+
+        verifyHttp(server).times(5,
+                                 method(Method.POST),
+                                 uri("/foo"));
+    }
+
+    @Test
+    public void shouldReturnDifferentBodyAndStatusForSameRequestBySingleSequence() {
+        whenHttp(server).
+                match(post("/foo")).
+                then(sequence(composite(status(CREATED_201), stringContent("status=CREATED")),
+                              composite(status(CONFLICT_409), stringContent("status=CONFLICT")),
+                              composite(status(CREATED_201), stringContent("status=CREATED2")),
+                              status(NOT_FOUND_404))
+                );
+
+        given().post("/foo").then().assertThat().statusCode(is(201)).body(equalTo("status=CREATED"));
+        given().post("/foo").then().assertThat().statusCode(is(409)).body(equalTo("status=CONFLICT"));
+        given().post("/foo").then().assertThat().statusCode(is(201)).body(equalTo("status=CREATED2"));
+        given().post("/foo").then().assertThat().statusCode(is(404)).body(isEmptyString());
+        given().post("/foo").then().assertThat().body(isEmptyString());
+
+        verifyHttp(server).times(5,
+                                 method(Method.POST),
+                                 uri("/foo"));
+    }
+
+    // two sequences in multiple whenHttp, different endpoints
+
+    @Test
+    public void shouldReturnDifferentResponseComplex() {
+        whenHttp(server).
+                match(get("/foo")).
+                then(sequence(
+                        status(NOT_FOUND_404),
+                        composite(status(OK_200), stringContent("INITIAL VALUE")),
+                        composite(status(OK_200), stringContent("UPDATED VALUE")),
+                        status(NOT_FOUND_404)
+                ));
+        whenHttp(server).
+                match(post("/foo"), withPostBody()).
+                then(sequence(
+                        status(CREATED_201),
+                        status(CONFLICT_409))
+                );
+        whenHttp(server).
+                match(put("/foo"), withPostBody()).
+                then(sequence(
+                        status(BAD_REQUEST_400),
+                        status(NO_CONTENT_204))
+                );
+        whenHttp(server).
+                match(delete("/foo")).
                 then(status(NO_CONTENT_204));
 
-        // business login to be tested
-        // 1. get current data
-        given().get("/demo")
-                .then().assertThat().body(equalTo("INITIAL VALUE"));
-        // 2. update data
-        given().body("UPDATED VALUE").put("/demo")
-                .then().assertThat().statusCode(is(NO_CONTENT_204.getStatusCode()));
-        // 3. use new data
-        given().get("/demo")
-                .then().assertThat().body(equalTo("UPDATED VALUE"));
+        given().get("/foo")
+                .then().assertThat().statusCode(is(NOT_FOUND_404.getStatusCode())).body(isEmptyString());
+        given().body("UPDATED VALUE").put("/foo")
+                .then().assertThat().statusCode(is(BAD_REQUEST_400.getStatusCode())).body(isEmptyString());
+        given().body("INITIAL VALUE").post("/foo")
+                .then().assertThat().statusCode(is(CREATED_201.getStatusCode())).body(isEmptyString());
+        given().get("/foo")
+                .then().assertThat().statusCode(is(OK_200.getStatusCode())).body(equalTo("INITIAL VALUE"));
+        given().body("INITIAL VALUE, AGAIN").post("/foo")
+                .then().assertThat().statusCode(is(CONFLICT_409.getStatusCode())).body(isEmptyString());
+        given().body("UPDATED VALUE").put("/foo")
+                .then().assertThat().statusCode(is(NO_CONTENT_204.getStatusCode())).body(isEmptyString());
+        given().get("/foo")
+                .then().assertThat().statusCode(is(OK_200.getStatusCode())).body(equalTo("UPDATED VALUE"));
+        given().delete("/foo")
+                .then().assertThat().statusCode(is(NO_CONTENT_204.getStatusCode())).body(isEmptyString());
+        given().get("/foo")
+                .then().assertThat().statusCode(is(NOT_FOUND_404.getStatusCode())).body(isEmptyString());
     }
 
 }

--- a/src/test/java/guide/SequencedSubActionsTest.java
+++ b/src/test/java/guide/SequencedSubActionsTest.java
@@ -1,0 +1,91 @@
+package guide;
+
+import com.jayway.restassured.RestAssured;
+import com.xebialabs.restito.semantics.Action;
+import com.xebialabs.restito.server.StubServer;
+import org.glassfish.grizzly.http.Method;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.jayway.restassured.RestAssured.given;
+import static com.xebialabs.restito.builder.stub.StubHttp.whenHttp;
+import static com.xebialabs.restito.builder.verify.VerifyHttp.verifyHttp;
+import static com.xebialabs.restito.semantics.Action.sequence;
+import static com.xebialabs.restito.semantics.Action.status;
+import static com.xebialabs.restito.semantics.Action.stringContent;
+import static com.xebialabs.restito.semantics.Condition.get;
+import static com.xebialabs.restito.semantics.Condition.method;
+import static com.xebialabs.restito.semantics.Condition.put;
+import static com.xebialabs.restito.semantics.Condition.uri;
+import static com.xebialabs.restito.semantics.Condition.withPostBody;
+import static org.glassfish.grizzly.http.util.HttpStatus.NO_CONTENT_204;
+import static org.glassfish.grizzly.http.util.HttpStatus.OK_200;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+
+/**
+ * Demonstrates use of {@link com.xebialabs.restito.semantics.Action#sequence(Action...)}.
+ */
+public class SequencedSubActionsTest {
+
+    private StubServer server;
+
+    @Before
+    public void start() {
+        server = new StubServer().run();
+        RestAssured.port = server.getPort();
+    }
+
+    @After
+    public void stop() {
+        server.stop();
+    }
+
+    @Test
+    public void shouldReturnDifferentBodyForSameRequest() {
+        whenHttp(server).
+                match(get("/demo")).
+                then(status(OK_200),
+                     sequence(stringContent("Hello Restito."),
+                              stringContent("Hello, again!"))
+                );
+
+        // First action from sequence:
+        given().get("/demo").then().assertThat().body(equalTo("Hello Restito."));
+        // Second action from sequence:
+        given().get("/demo").then().assertThat().body(equalTo("Hello, again!"));
+        // Noop action:
+        given().get("/demo").then().assertThat().body(isEmptyString());
+
+        verifyHttp(server).times(3,
+                                 method(Method.GET),
+                                 uri("/demo"));
+    }
+
+    @Test
+    public void shouldReturnDifferentBodyForSameRequestExpectedUsage() {
+        whenHttp(server).
+                match(get("/demo")).
+                then(status(OK_200),
+                     sequence(stringContent("INITIAL VALUE"),
+                              stringContent("UPDATED VALUE"))
+                );
+        whenHttp(server).
+                match(put("/demo"), withPostBody()).
+                then(status(NO_CONTENT_204));
+
+        // business login to be tested
+        // 1. get current data
+        given().get("/demo")
+                .then().assertThat().body(equalTo("INITIAL VALUE"));
+        // 2. update data
+        given().body("UPDATED VALUE").put("/demo")
+                .then().assertThat().statusCode(is(NO_CONTENT_204.getStatusCode()));
+        // 3. use new data
+        given().get("/demo")
+                .then().assertThat().body(equalTo("UPDATED VALUE"));
+    }
+
+}


### PR DESCRIPTION
Hi Mike.

This is suggestion how to extend Action API to support different response for identical requests repeated in sequence.

Let me know if you like the idea or if you prefer to make it different way.

Thanks,
Libor
