### PR TITLE
Fixes setting of content type for large content files

### DIFF
--- a/src/main/java/com/xebialabs/restito/semantics/Action.java
+++ b/src/main/java/com/xebialabs/restito/semantics/Action.java
@@ -115,9 +115,9 @@ public class Action implements Applicable {
             Action mainAction = bytesContent(bytes);
 
             if (fileExtension.equalsIgnoreCase("xml")) {
-                mainAction = composite(mainAction, contentType("application/xml"));
+                mainAction = composite(contentType("application/xml"), mainAction);
             } else if (fileExtension.equalsIgnoreCase("json")) {
-                mainAction = composite(mainAction, contentType("application/json"));
+                mainAction = composite(contentType("application/json"), mainAction);
             }
 
             return mainAction;


### PR DESCRIPTION
For large content files (larger than org.glassfish.grizzly.http.io.OutputBuffer.DEFAULT_BUFFER_SIZE = 8 * 1024), the content gets flushed before the contentType header is set. Reordering this ensures content type will be set before the headers are flushed. See separate pull request for an integration test that shows this (feel free to reject that one if the test seems too much)