### PR TITLE
Support of multi-valued headers

### DIFF
--- a/src/main/java/com/xebialabs/restito/semantics/Call.java
+++ b/src/main/java/com/xebialabs/restito/semantics/Call.java
@@ -2,8 +2,8 @@ package com.xebialabs.restito.semantics;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+
 import org.glassfish.grizzly.http.Method;
 import org.glassfish.grizzly.http.server.Request;
 
@@ -18,6 +18,7 @@ public class Call {
     private String postBody;
     private String url;
     private String authorization;
+    private Map<String, String[]> multiHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private Map<String, String> headers = new HashMap<>();
     private Map<String, String[]> parameters = new HashMap<>();
     private Request request;
@@ -40,6 +41,10 @@ public class Call {
 
         for (String s : request.getHeaderNames()) {
             call.headers.put(s, request.getHeader(s));
+
+            final List<String> values = new ArrayList<>();
+            request.getHeaders(s).forEach(values::add);
+            call.multiHeaders.put(s, values.toArray(new String[values.size()]));
         }
 
         call.parameters = new HashMap<>(request.getParameterMap());
@@ -76,6 +81,13 @@ public class Call {
      */
     public Map<String, String> getHeaders() {
         return headers;
+    }
+
+    /**
+     * Map of headers. All headers considered as if they were multi-valued.
+     */
+    public Map<String, String[]> getMultiHeaders() {
+        return multiHeaders;
     }
 
     /**

--- a/src/test/java/com/xebialabs/restito/semantics/ConditionTest.java
+++ b/src/test/java/com/xebialabs/restito/semantics/ConditionTest.java
@@ -2,6 +2,7 @@ package com.xebialabs.restito.semantics;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.glassfish.grizzly.http.Method;
@@ -84,6 +85,15 @@ public class ConditionTest {
         map1 = paramsMap("bar", "foo2", "foo1");
         when(call.getParameters()).thenReturn(map1);
         assertFalse(condition.check(call));
+    }
+
+    @Test
+    public void shouldDistinguishParameterPresence() throws Exception {
+        Map<String, String[]> map1 = paramsMap("bar", "foo1", "foo2");
+        when(call.getParameters()).thenReturn(map1);
+
+        assertTrue(Condition.hasParameter("bar").check(call));
+        assertFalse(Condition.hasParameter("baz").check(call));
     }
 
     @Test
@@ -231,6 +241,37 @@ public class ConditionTest {
     }
 
     @Test
+    public void shouldDistinguishByMultiHeaderHeader() {
+        Condition withFzzContainsBar = Condition.withMultiHeaderContains("fzz", "bar");
+        Condition withEmptyFzz = Condition.withMultiHeaderContains("fzz");
+        Condition withFooContainsBarBaz = Condition.withMultiHeaderContains("foo", "bar", "baz");
+        Condition withFooContainsBazBar = Condition.withMultiHeaderContains("fOo", "baz", "bar");
+        Condition withFooContainsBar = Condition.withMultiHeaderContains("foo", "bar");
+        Condition withFooContainsBas = Condition.withMultiHeaderContains("foo", "bas");
+        Condition withZzzContainsBar = Condition.withMultiHeaderContains("zzz", "bar");
+
+        Condition withFooMatchesBarBaz = Condition.withMultiHeaderMatches("foo", "bar", "baz");
+        Condition withFooMatchesBar = Condition.withMultiHeaderMatches("foo", "bar");
+
+        when(call.getMultiHeaders())
+                .thenReturn(multiHeader("fzz"))
+                .thenReturn(multiHeader("fzz"))
+                .thenReturn(multiHeader("foo", "bar", "baz"));
+
+        assertTrue(withEmptyFzz.check(call));
+        assertFalse(withFzzContainsBar.check(call));
+
+        assertTrue(withFooContainsBarBaz.check(call));
+        assertTrue(withFooContainsBazBar.check(call));
+        assertTrue(withFooContainsBar.check(call));
+        assertFalse(withFooContainsBas.check(call));
+        assertFalse(withZzzContainsBar.check(call));
+
+        assertTrue(withFooMatchesBarBaz.check(call));
+        assertFalse(withFooMatchesBar.check(call));
+    }
+
+    @Test
     public void headersShouldBeCaseInsensitive() {
         when(call.getHeaders()).thenReturn(header("foo", "bar"));
         assertTrue(Condition.withHeader("fOo").check(call));
@@ -311,5 +352,11 @@ public class ConditionTest {
         return new HashMap<String, String>() {{
             put(key, value);
         }};
+    }
+
+    private Map<String, String[]> multiHeader(final String key, final String... values) {
+        final TreeMap<String, String[]> map = new TreeMap<String, String[]>(String.CASE_INSENSITIVE_ORDER);
+        map.put(key, values);
+        return map;
     }
 }


### PR DESCRIPTION
It's good to have Condition for cases where the request contains more than one value, associated with single header name. Example:
```
Set-Cookie: id=a3fWa; Expires=Mon, 04 Sep 2017 07:28:00 GMT
Set-Cookie: id=w14hS; Expires=Tue, 05 Sep 2017 12:43:00 GMT
```

Also, `hasParameter` Condition was added to check parameter presence

Can you please review the PR?