### PR TITLE
Update mina-core dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
 	compile 'com.jayway.jsonpath:json-path:2.1.0'
 
-	compile 'org.apache.mina:mina-core:2.0.13'
+	compile 'org.apache.mina:mina-core:2.1.6'
 
 	testCompile 'org.hamcrest:hamcrest-all:1.3'
 


### PR DESCRIPTION
The existing version contains [CVE-2019-0231](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-0231). Though, restito is not impacted due to its limited usage. My dependency scanner still flags it. So, why not update to latest to shut them up?