### PR TITLE
Fix regression in 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ public class SimpleRequestsTest {
 <dependency>
     <groupId>com.xebialabs.restito</groupId>
     <artifactId>restito</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,9 +34,9 @@ dependencies {
 	testImplementation"com.typesafe.akka:akka-http_2.12:10.1.5"
 	testImplementation"org.scalatest:scalatest_2.12:3.0.5"
 
+	api 'org.glassfish.grizzly:grizzly-http-server:2.3.25'
 	implementation 'junit:junit:4.13.2'
 	implementation 'org.slf4j:slf4j-api:1.7.21'
-	implementation 'org.glassfish.grizzly:grizzly-http-server:2.3.25'
 	implementation 'com.jayway.jsonpath:json-path:2.7.0'
 	implementation 'org.apache.mina:mina-core:2.1.6'
 }
@@ -114,6 +114,8 @@ publishing {
 
 }
 
+/*
 signing {
 	sign publishing.publications.mavenJava
 }
+*/

--- a/examples/popular-page/build.gradle
+++ b/examples/popular-page/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin:'application'
 
 
-sourceCompatibility = 1.8
+sourceCompatibility = 11
 version = '1.0'
 
 

--- a/examples/popular-page/build.gradle
+++ b/examples/popular-page/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-  testImplementation 'com.xebialabs.restito:restito:1.0.0' //  Restito dependency
+  testImplementation 'com.xebialabs.restito:restito:1.0.1' //  Restito dependency
 
   //  Note, that to have nice logging from Restito, you must have one of slf4j bindings on the classpath
   //  More info here: http://slf4j.org/faq.html#configure_logging

--- a/examples/popular-page/pom.xml
+++ b/examples/popular-page/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.xebialabs.restito</groupId>
             <artifactId>restito</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/examples/standalone-server/build.gradle
+++ b/examples/standalone-server/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'com.xebialabs.restito:restito:1.0.0' //  Restito dependency
+  implementation 'com.xebialabs.restito:restito:1.0.1' //  Restito dependency
 }
 
 mainClassName = "com.xebialabs.restito.examples.MyServer"

--- a/releases.md
+++ b/releases.md
@@ -5,6 +5,7 @@ Restito releases
 
 * 1.0.1
     * (fix) Broken dependency
+    * (fix) Critical racing condition on Stub Server while registering the calls. See #74
 
 * 1.0.0
     * Gradle 7 and  Java 11 (#82) 

--- a/releases.md
+++ b/releases.md
@@ -3,6 +3,9 @@ Restito releases
 
 ## 1.x (Java 11+)
 
+* 1.0.1
+    * (fix) Broken dependency
+
 * 1.0.0
     * Gradle 7 and  Java 11 (#82) 
 

--- a/src/main/java/com/xebialabs/restito/server/StubServer.java
+++ b/src/main/java/com/xebialabs/restito/server/StubServer.java
@@ -228,6 +228,10 @@ public class StubServer {
 
                 CallsHelper.logCall(call);
 
+                if (isRegisterCalls()) {
+                    calls.add(call);
+                }
+
                 boolean processed = false;
                 ListIterator<Stub> iterator = stubs.listIterator(stubs.size());
                 while (iterator.hasPrevious()) {
@@ -244,9 +248,6 @@ public class StubServer {
                 if (!processed) {
                     response.setStatus(HttpStatus.NOT_FOUND_404);
                     log.warn("Request {} hasn't been covered by any of {} stubs.", request.getRequestURI(), stubs.size());
-                }
-                if (isRegisterCalls()) {
-                    calls.add(call);
                 }
             }
         };


### PR DESCRIPTION
- Declare Grizzly as `api` dependency as APIs like `Action#status` uses Grizzly classes
- The fix the racing reported in #74 was not ported over to 1.x. I cherry-picked the original commit with necessary changes to fit 1.x.

With these changes, I would like to request for a 1.0.1 release to make it usable.